### PR TITLE
fix add_rows

### DIFF
--- a/operators/src/add_rows/common_cpu/mod.rs
+++ b/operators/src/add_rows/common_cpu/mod.rs
@@ -104,9 +104,6 @@ impl crate::Operator for Operator {
             (ty::F64, ty::U64) => calculate!(f64, u64),
             (_, _) => todo!(),
         }
-
-        calculate!(f16, u32);
-
         Ok(())
     }
 }


### PR DESCRIPTION
删除多余的calculate，否则会一直按照f16的精度计算